### PR TITLE
Small updates for consistency across document

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ Archives configuration is done in the site's `_config.yml` file, under the `jeky
 ```yml
 jekyll-archives:
   enabled: []
-  layout: 'archive'
+  layout: archive
   permalinks:
     year: '/:year/'
     month: '/:year/:month/'
@@ -88,6 +88,7 @@ layouts:
   year: year-archive
   month: month-archive
   day: day-archive
+  category: category-archive
   tag: tag-archive-layout
 ```
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Removed single quotes around layout value in default configuration to match the style of the rest of the page.

Add category layout in sample values.